### PR TITLE
Update Pokémon GO

### DIFF
--- a/CS-EnhancedTableLayouter.user.js
+++ b/CS-EnhancedTableLayouter.user.js
@@ -121,9 +121,16 @@ We use hardcoded IDs instead of just index within the page so that the addition 
 				},
 				{
 					tables: tables,
-					groupStart: 15,
-					groupEnd: 19,
+					groupStart: 13,
+					groupEnd: 16,
 					tableID: 3,
+					tableName: "Gigantamax Pokédex",
+				},
+				{
+					tables: tables,
+					groupStart: 18,
+					groupEnd: 22,
+					tableID: 4,
 					tableName: "Sizes",
 				},
 			]


### PR DESCRIPTION
The addition of Gigantamax groups broke the Navtable for Pokémon GO. This commit fixes this problem and also adds a new NavTable dedicated towards Gigantamax itself.